### PR TITLE
Fix the unhandled exception and test validation in manual tests

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/DataCommon/DataTestUtility.cs
@@ -151,7 +151,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             return ex;
         }
 
-        public static TException ExpectFailure<TException>(Action actionThatFails, string exceptionMessage = null, bool innerExceptionMustBeNull = false, Func<TException, bool> customExceptionVerifier = null) where TException : Exception
+        public static TException ExpectFailure<TException>(Action actionThatFails, string[] exceptionMessages, bool innerExceptionMustBeNull = false, Func<TException, bool> customExceptionVerifier = null) where TException : Exception
         {
             try
             {
@@ -161,14 +161,14 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             }
             catch (Exception ex)
             {
-                if ((CheckException<TException>(ex, exceptionMessage, innerExceptionMustBeNull)) && ((customExceptionVerifier == null) || (customExceptionVerifier(ex as TException))))
+                foreach (string exceptionMessage in exceptionMessages)
                 {
-                    return (ex as TException);
+                    if ((CheckException<TException>(ex, exceptionMessage, innerExceptionMustBeNull)) && ((customExceptionVerifier == null) || (customExceptionVerifier(ex as TException))))
+                    {
+                        return (ex as TException);
+                    }
                 }
-                else
-                {
-                    throw;
-                }
+                throw;
             }
         }
 


### PR DESCRIPTION
There are 2 changes in this PR
1. Handle any exceptions that cannot be verified by the DataTestUtility so that they are not put on the ThreadPool, which is causing the crash
2. In case of Command Cancel tests, based on how far along the command is in progress, the test can break because a different exception message is sent to the client. Making `ExpectFailure` handle multiple messages and check for multiple strings from the test